### PR TITLE
:sparkles: add config to reinforce rule application

### DIFF
--- a/src/configuration/config.py
+++ b/src/configuration/config.py
@@ -34,3 +34,8 @@ class Config(BaseModel):
     """
     A list of process names to be excluded from all rules.
     """
+
+    processReinforceRuleList: List[str] = Field(default_factory=list)
+    """
+    A list of process names to which rule application will be reinforced until process status regarding to rule stops reverting back.
+    """

--- a/src/service/rules_service.py
+++ b/src/service/rules_service.py
@@ -52,14 +52,14 @@ class RulesService(ABC):
 
         if force:
             LOG.info("Configuration file has been modified. Reloading all rules to apply changes.")
-            processes = ProcessesInfoService.get_list()
+            processes = ProcessesInfoService.get_list(config)
         else:
             processes = ProcessesInfoService.get_new_processes()
 
         cls.__handle_processes(config, processes, services)
 
     @classmethod
-    def __handle_processes(cls, config: Config, processes, services):
+    def __handle_processes(cls, config: Config, processes: dict[int, Process], services: dict[int, Service]):
         process_exclusion_list = set(config.processExclusionList)
 
         for pid, process_info in processes.items():


### PR DESCRIPTION
- Adds configuration to reinforce rule application for the given processes names until the rule related attribute stops changing.